### PR TITLE
Add method to clear an input field

### DIFF
--- a/lib/world.js
+++ b/lib/world.js
@@ -140,6 +140,13 @@ const World = (() => {
           retries, timeout))
     }
 
+    clear (selector, retries, timeout) {
+      return this.waitFor(selector, retries, timeout)
+        .then((el) => waitFor(this, el,
+          (el) => el.setAttribute('value', ''),
+          retries, timeout))
+    }
+
     static use (extend) {
       return extend(this)
     }

--- a/test/world.spec.js
+++ b/test/world.spec.js
@@ -146,7 +146,8 @@ describe('world class', function () {
         hover: () => Promise.resolve(el),
         click: () => Promise.resolve(el),
         getText: () => 'random text',
-        getAttribute: () => 'random value'
+        getAttribute: () => 'random value',
+        setAttribute: sinon.stub()
       }
       corRoutines = {
         waitForTitle: () => Promise.resolve(true),
@@ -373,6 +374,14 @@ describe('world class', function () {
           throw err
         })
     })
+
+    it('clear', function () {
+      sinon.spy(corRoutines, 'waitFor')
+      return world.clear('abc')
+        .then(() => {
+          corRoutines.waitFor.restore()
+          el.setAttribute.calledWith('value', '').should.be.true
+        })
+    })
   })
 })
-


### PR DESCRIPTION
Sometimes you need to clear an input field before you sendKeys.
